### PR TITLE
Initial version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,13 @@ coverage.txt
 *.so
 *.dylib
 
+# Binaries for Go
+debug
+release
+debug/
+release/
+steamer
+
 # Test binary, build with `go test -c`
 *.test
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Launch",
+      "type": "go",
+      "request": "launch",
+      "mode": "debug",
+      "remotePath": "",
+      "port": 2345,
+      "host": "127.0.0.1",
+      "program": "${fileDirname}",
+      "env": {},
+      "args": [],
+      "showLog": true
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-[![Build Status](https://travis-ci.org/Didstopia/steam-update-checker.svg?branch=master)](https://travis-ci.org/Didstopia/steam-update-checker)
+[![Build Status](https://travis-ci.org/Didstopia/steam-update-checker.svg?branch=master)](https://travis-ci.org/Didstopia/steamer)
 
-# Steam Update Checker
+# steamer
 
-A universal Steam update check utility, written in Go.
+A steamcmd wrapper, made primarily for easy update checking.
 
 **NOTICE:** _Work in progress._
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/Didstopia/steam-update-checker.svg?branch=master)](https://travis-ci.org/Didstopia/steam-update-checker)
+
 # Steam Update Checker
 
 A universal Steam update check utility, written in Go.

--- a/main.go
+++ b/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hi.")
+}

--- a/main.go
+++ b/main.go
@@ -1,7 +1,50 @@
 package main
 
-import "fmt"
+import (
+	"fmt"
+	"os"
+	"unicode"
+
+	"github.com/Didstopia/steamer/steamcmd"
+)
 
 func main() {
-	fmt.Println("Hi.")
+	// Verify that we have arguments
+	args := os.Args[1:]
+	if len(args) <= 1 {
+		fmt.Println("Missing required argument (try adding --appinfo <APP_ID>)")
+		os.Exit(1)
+	}
+
+	// Verify that we have a valid action
+	action := args[0]
+	if action == "" || isInt(action) {
+		fmt.Println("Invalid argument specified:", action)
+		os.Exit(1)
+	}
+
+	// Verify that a valid app id was specified
+	appID := args[1]
+	if appID == "" || !isInt(appID) {
+		fmt.Println("Invalid App ID specified:", appID)
+		os.Exit(1)
+	}
+
+	//fmt.Println("Loading app info for App ID:", appID)
+
+	if action == "--appinfo" {
+		fmt.Println(steamcmd.AppInfo(appID))
+	} else {
+		fmt.Println("Invalid or unsupported argument specified:", action)
+		os.Exit(1)
+	}
+}
+
+func isInt(s string) bool {
+	for _, c := range s {
+		if !unicode.IsDigit(c) {
+			return false
+		}
+	}
+	return true
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,7 @@
+package main
+
+import "testing"
+
+func TestStuff(t *testing.T) {
+
+}

--- a/steamcmd/steamcmd.go
+++ b/steamcmd/steamcmd.go
@@ -1,0 +1,154 @@
+package steamcmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/hokaccha/go-prettyjson"
+	"github.com/mholt/archiver"
+)
+
+// AppInfo returns a JSON string containing information about the Steam app
+func AppInfo(appID string) string {
+	return run([]string{"+login", "anonymous", "+app_info_update", "1", "+app_info_print", appID, "+quit"})
+}
+
+func run(args []string) string {
+	// Check if steamcmd already exists
+	binary, lookErr := exec.LookPath(steamcmdBinaryPath)
+	if lookErr != nil {
+		// Download steamcmd
+		download(steamcmdDownloadPath, steamcmdDownloadURL)
+
+		// Unzip the downloaded file
+		err := archiver.TarGz.Open(steamcmdDownloadPath, steamcmdPath)
+		if err != nil {
+			log.Fatal("Extraction failed:", err)
+			os.Exit(1)
+		}
+
+		// Check that steamcmd exists, but this time fail if it doesn't exist
+		_, lookErr := exec.LookPath(steamcmdBinaryPath)
+		if lookErr != nil {
+			log.Fatal("Installation failed:", lookErr)
+			os.Exit(1)
+		}
+	}
+
+	// TODO: Remove the "appinfo.vdf" cache file before running the command!
+
+	//	Format the command
+	cmd := exec.Command(binary, args...)
+
+	//	Sanity check -- capture stdout and stderr:
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+
+	//	Run the command
+	cmd.Run()
+
+	//	Output our results
+	result := appInfoFormat(out.String())
+	error := stderr.String()
+	if error != "" {
+		log.Fatal("Command failed:", stderr.String())
+		os.Exit(1)
+	}
+	if result == "" {
+		log.Fatal("Command failed: No output or invalid app info")
+		os.Exit(1)
+	}
+
+	return result
+}
+
+func appInfoFormat(appInfo string) string {
+
+	// TODO: This can panic, so we need to be able to catch it!
+	// Get the app info part of the incoming data
+	result := "{\n\t" + strings.Split(appInfo, "\"\n{\n\t")[1]
+
+	// Remove tabs
+	result = strings.Replace(result, "\t", "", -1)
+
+	// Add missing semicolons
+	result = strings.Replace(result, "\"\n{", "\":\n{", -1)
+	result = strings.Replace(result, "\"\"", "\":\"", -1)
+
+	// Add missing commas
+	result = strings.Replace(result, "}\n\"", "},\n\"", -1)
+	result = strings.Replace(result, "\"\n\"", "\",\n\"", -1)
+
+	// Remove newlines last
+	result = strings.Replace(result, "\n", "", -1)
+
+	// Validate that we have a proper JSON string
+	if !isJSON(result) {
+		log.Fatal("Parsing failed, invalid JSON:", result)
+		os.Exit(1)
+	}
+
+	// Convert to pretty printed JSON
+	in := []byte(result)
+	var raw map[string]interface{}
+	json.Unmarshal(in, &raw)
+	prettyJSON, prettyErr := prettyjson.Marshal(raw)
+	if prettyErr != nil {
+		log.Fatal("Pretty JSON failed:", prettyErr)
+		os.Exit(1)
+	}
+
+	// Verify that we have a valid JSON string again
+	result = string(prettyJSON)
+	if result == "" {
+		log.Fatal("Pretty JSON failed: Empty JSON string")
+		os.Exit(1)
+	}
+
+	// Return the parsed result
+	return string(result)
+}
+
+func download(filepath string, url string) error {
+	// Create the file
+	out, err := os.Create(filepath)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	// Get the data
+	resp, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	// Write the body to file
+	_, err = io.Copy(out, resp.Body)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func isJSONString(s string) bool {
+	var js string
+	return json.Unmarshal([]byte(s), &js) == nil
+
+}
+
+func isJSON(s string) bool {
+	var js map[string]interface{}
+	return json.Unmarshal([]byte(s), &js) == nil
+
+}

--- a/steamcmd/steamcmd_linux.go
+++ b/steamcmd/steamcmd_linux.go
@@ -1,0 +1,8 @@
+// +build linux
+
+package steamcmd
+
+const steamcmdDownloadURL = "https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz"
+const steamcmdDownloadPath = "/tmp/steamcmd.tar.gz"
+const steamcmdPath = "/tmp/steamcmd"
+const steamcmdBinaryPath = "/tmp/steamcmd/steamcmd.sh"

--- a/steamcmd/steamcmd_macos.go
+++ b/steamcmd/steamcmd_macos.go
@@ -1,0 +1,8 @@
+// +build darwin
+
+package steamcmd
+
+const steamcmdDownloadURL = "https://steamcdn-a.akamaihd.net/client/installer/steamcmd_osx.tar.gz"
+const steamcmdDownloadPath = "/tmp/steamcmd.tar.gz"
+const steamcmdPath = "/tmp/steamcmd"
+const steamcmdBinaryPath = "/tmp/steamcmd/steamcmd.sh"

--- a/steamcmd/steamcmd_test.go
+++ b/steamcmd/steamcmd_test.go
@@ -1,0 +1,7 @@
+package steamcmd
+
+import "testing"
+
+func TestStuff(t *testing.T) {
+
+}

--- a/steamcmd/steamcmd_windows.go
+++ b/steamcmd/steamcmd_windows.go
@@ -1,0 +1,8 @@
+// +build windows
+
+package steamcmd
+
+const steamcmdDownloadURL = "https://steamcdn-a.akamaihd.net/client/installer/steamcmd.zip"
+const steamcmdDownloadPath = "C:\\Temp\\steamcmd.zip"
+const steamcmdPath = "C:\\Temp\\steamcmd"
+const steamcmdBinaryPath = "C:\\Temp\\steamcmd\\steamcmd.bat"


### PR DESCRIPTION
This version should install steamcmd, as well as support a single command `--appinfo <APP_ID>`, which fetches the app info for that particular Steam title, parses it and spits out pretty printed but valid JSON.

Additionally, this should (in theory) work across supported platforms, so Windows, macOS and Linux.